### PR TITLE
Update action to use Node.js v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
Node 12 has been out of support since April 2022, as a result GitHub has started the deprecation process of Node 12 for GitHub Actions. GitHub plans to migrate all actions to run on Node16 by Summer 2023.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/