### PR TITLE
Update message to indicate what actually failed

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ async function main() {
     deploymentStatus.state = 'failure';
     deploymentStatus.environment_url = await getFailureURL();
     if (!process.env.WORKFLOW_CI) {
-      core.setFailed("Deployment failed");
+      core.setFailed("Deployment to Oxygen failed. Check the 'Build and Publish to Oxygen' step for more information.");
     }
   }
 


### PR DESCRIPTION
This is a bit confusing since we fail the workflow on this step instead of the actual step that had the issue. We still want this to run so we can create the failed deployment on Github, but the real error is in the previous step so hoping this makes that clearer.