### PR TITLE
Succeed the action even on failed deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   error:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Fake Errored Deploy
         id: deploy
         run: echo "ERROR!!" 1>&2
@@ -25,7 +25,7 @@ jobs:
     needs: [error]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Fake Successful Deploy
         id: deploy
         run: echo "preview_url=https://shopify.dev/hydrogen" >> "$GITHUB_OUTPUT"

--- a/index.js
+++ b/index.js
@@ -55,9 +55,6 @@ async function main() {
   } else {
     deploymentStatus.state = 'failure';
     deploymentStatus.environment_url = await getFailureURL();
-    if (!process.env.WORKFLOW_CI) {
-      core.setFailed("Deployment to Oxygen failed. Check the 'Build and Publish to Oxygen' step for more information.");
-    }
   }
 
   await octokit.rest.repos.createDeploymentStatus(deploymentStatus);

--- a/index.js
+++ b/index.js
@@ -3,8 +3,6 @@ const github = require('@actions/github');
 
 const { owner, repo } = github.context.repo;
 const ref = process.env.GITHUB_REF;
-const sha = process.env.GITHUB_SHA;
-const creator = process.env.ACTOR;
 const environment = core.getInput('environment', {
   required: true,
 });


### PR DESCRIPTION
If we failed to generate a deployment then that step will have failures on it. We want this action to always succeed because both successful and failed deployment messages are valid results.

| Before | After |
| -- | -- |
| <img src="https://github.com/Shopify/github-deployment-action/assets/836758/1efc1dc2-dd5b-4462-b28b-d941bf69eeba"> | <img width="316" alt="image" src="https://github.com/Shopify/github-deployment-action/assets/836758/dfc2c08c-9431-4b5a-9d71-8b296ef95d89"> |
